### PR TITLE
Refaktoring, poprawa stylu kodu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 examples/captcha.jpeg
 .idea
 phpunit.xml
+.php_cs.cache
+.php_cs

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,17 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in('./src')
+    ->in('./tests');
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'phpdoc_add_missing_param_annotation' => true,
+        'linebreak_after_opening_tag' => true,
+        'phpdoc_summary' => false,
+        'phpdoc_no_package' => false,
+        'phpdoc_order' => true,
+        'phpdoc_align' => true,
+    ])
+    ->setFinder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,17 @@ language: php
 php:
   - 7.1
   - 7.2
+  - nightly
+
+allow_failures:
+  php: nightly
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 install:
-  - composer install --no-interaction --no-progress
+  - composer install --no-interaction --no-progress || composer remove --dev friendsofphp/php-cs-fixer --no-interaction --no-progress
 
 script:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Gus Api Library for PHP",
   "type" : "library",
   "license": "LGPL-2.1-or-later",
-  "keywords":["nip","regon","krs","api", "soap", "library", "GUS", "CEGID"],
+  "keywords":["nip","regon","krs","api", "soap", "library", "GUS", "CEIDG"],
   "authors": [
     {
       "name": "Janusz Żukowicz",
@@ -12,12 +12,13 @@
   ],
   "require": {
     "php" : "^7.1",
-    "ext-soap": "*",
-    "squizlabs/php_codesniffer": "^3.2",
-    "phpstan/phpstan-shim": "^0.9.2"
+    "ext-soap": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpstan/phpstan-shim": "^0.9.2",
+    "phpunit/phpunit": "^7.0",
+    "squizlabs/php_codesniffer": "^3.2",
+    "friendsofphp/php-cs-fixer": "^2.11"
   },
   "autoload":{
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,98 +4,139 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4cb3ba19015dad42efe8a23d8a54dcb",
-    "packages": [
+    "content-hash": "72fdf04bf89b59844879b73d89d9dd8f",
+    "packages": [],
+    "packages-dev": [
         {
-            "name": "phpstan/phpstan-shim",
-            "version": "0.9.2",
+            "name": "composer/semver",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan-shim.git",
-                "reference": "e4720fb2916be05de02869780072253e7e0e8a75"
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e4720fb2916be05de02869780072253e7e0e8a75",
-                "reference": "e4720fb2916be05de02869780072253e7e0e8a75",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.0"
+                "php": "^5.3.2 || ^7.0"
             },
-            "replace": {
-                "phpstan/phpstan": "self.version"
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
             },
-            "bin": [
-                "phpstan",
-                "phpstan.phar"
-            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9-dev"
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "PHPStan Phar distribution",
-            "time": "2018-01-28T14:29:27+00:00"
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-08-30T16:08:34+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.2.3",
+            "name": "doctrine/annotations",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
                 "shasum": ""
             },
             "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
             },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
             "keywords": [
-                "phpcs",
-                "standards"
+                "annotations",
+                "docblock",
+                "parser"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
-        }
-    ],
-    "packages-dev": [
+            "time": "2017-12-06T07:11:42+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.1.0",
@@ -151,6 +192,154 @@
             "time": "2017-07-22T11:58:36+00:00"
         },
         {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "ad94441c17b8ef096e517acccdbf3238af8a2da8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ad94441c17b8ef096e517acccdbf3238af8a2da8",
+                "reference": "ad94441c17b8ef096e517acccdbf3238af8a2da8",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || >=7.0 <7.3",
+                "php-cs-fixer/diff": "^1.3",
+                "symfony/console": "^3.2 || ^4.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0",
+                "symfony/filesystem": "^3.0 || ^4.0",
+                "symfony/finder": "^3.0 || ^4.0",
+                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0",
+                "symfony/stopwatch": "^3.0 || ^4.0"
+            },
+            "conflict": {
+                "hhvm": "*"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.0",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.0",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
+                "phpunitgoodpractices/traits": "^1.3.1",
+                "symfony/phpunit-bridge": "^3.2.2 || ^4.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationCaseFactory.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/Constraint/SameStringsConstraint.php",
+                    "tests/Test/Constraint/SameStringsConstraintForV5.php",
+                    "tests/Test/Constraint/SameStringsConstraintForV7.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/Test/IntegrationCaseFactoryInterface.php",
+                    "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/TestCase.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2018-03-21T17:41:26+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.7.0",
             "source": {
@@ -194,6 +383,54 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
+                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-04-04T21:24:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -296,6 +533,57 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -511,6 +799,43 @@
                 "stub"
             ],
             "time": "2018-04-18T13:57:24+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-shim",
+            "version": "0.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-shim.git",
+                "reference": "e4720fb2916be05de02869780072253e7e0e8a75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e4720fb2916be05de02869780072253e7e0e8a75",
+                "reference": "e4720fb2916be05de02869780072253e7e0e8a75",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.0"
+            },
+            "replace": {
+                "phpstan/phpstan": "self.version"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Phar distribution",
+            "time": "2018-01-28T14:29:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1459,6 +1784,611 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "aad9a6fe47319f22748fd764f52d3a7ca6fa6b64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/aad9a6fe47319f22748fd764f52d3a7ca6fa6b64",
+                "reference": "aad9a6fe47319f22748fd764f52d3a7ca6fa6b64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-04-03T05:24:00+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "63353a71073faf08f62caab4e6889b06a787f07b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/63353a71073faf08f62caab4e6889b06a787f07b",
+                "reference": "63353a71073faf08f62caab4e6889b06a787f07b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-04-06T07:35:43+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21",
+                "reference": "5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-22T10:50:29+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ca27c02b7a3fef4828c998c2ff9ba7aae1641c49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ca27c02b7a3fef4828c998c2ff9ba7aae1641c49",
+                "reference": "ca27c02b7a3fef4828c998c2ff9ba7aae1641c49",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-04-04T05:10:37+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "371532a2cfe932f7a3766dd4c45364566def1dd0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/371532a2cfe932f7a3766dd4c45364566def1dd0",
+                "reference": "371532a2cfe932f7a3766dd4c45364566def1dd0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2018-01-18T22:19:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "3532bfcd8f933a7816f3a0a59682fc404776600f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/3532bfcd8f933a7816f3a0a59682fc404776600f",
+                "reference": "3532bfcd8f933a7816f3a0a59682fc404776600f",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "8eca20c8a369e069d4f4c2ac9895144112867422"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/8eca20c8a369e069d4f4c2ac9895144112867422",
+                "reference": "8eca20c8a369e069d4f4c2ac9895144112867422",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-31T17:43:24+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25",
+                "reference": "d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-04-03T05:24:00+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "6795ffa2f8eebedac77f045aa62c0c10b2763042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6795ffa2f8eebedac77f045aa62c0c10b2763042",
+                "reference": "6795ffa2f8eebedac77f045aa62c0c10b2763042",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-19T16:50:22+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/GusApi/Adapter/AdapterInterface.php
+++ b/src/GusApi/Adapter/AdapterInterface.php
@@ -1,8 +1,12 @@
 <?php
+
 namespace GusApi\Adapter;
+
+use GusApi\Exception\NotFoundException;
 
 /**
  * Interface AdapterInterface interface of GUS api adapter
+ *
  * @package GusApi\Adapter\
  */
 interface AdapterInterface
@@ -11,6 +15,7 @@ interface AdapterInterface
      * Login in to regon server
      *
      * @param string $userKey twenty-character user key eg. <b>abcde12345abcde12345</b>
+     *
      * @return string session id - used in other actions
      */
     public function login(string $userKey): string;
@@ -19,6 +24,7 @@ interface AdapterInterface
      * Logout from regon server
      *
      * @param string $sid session id
+     *
      * @return bool logout status
      */
     public function logout(string $sid): bool;
@@ -26,8 +32,11 @@ interface AdapterInterface
     /**
      * Search data in regon server
      *
-     * @param string $sid session id
-     * @param array $parameters search parameters
+     * @param string $sid        session id
+     * @param array  $parameters search parameters
+     *
+     * @throws NotFoundException
+     *
      * @return mixed
      */
     public function search(string $sid, array $parameters);
@@ -38,6 +47,9 @@ interface AdapterInterface
      * @param string $sid session id
      * @param $regon
      * @param $reportType
+     *
+     * @throws NotFoundException
+     *
      * @return mixed
      */
     public function getFullData(string $sid, string $regon, string $reportType);
@@ -47,6 +59,7 @@ interface AdapterInterface
      *
      * @param string $sid session id
      * @param $param - available param names: ["StatusSesji", "KomunikatKod", "KomunikatTresc"]
+     *
      * @return mixed
      */
     public function getValue(?string $sid, string $param);

--- a/src/GusApi/Adapter/Soap/Exception/NoDataException.php
+++ b/src/GusApi/Adapter/Soap/Exception/NoDataException.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace GusApi\Adapter\Soap\Exception;
 
 class NoDataException extends \Exception
 {
-
 }

--- a/src/GusApi/Client/RequestDecoder.php
+++ b/src/GusApi/Client/RequestDecoder.php
@@ -1,18 +1,16 @@
 <?php
+
 namespace GusApi\Client;
 
-/**
- * Class RequestDecoder
- * @package GusApi\Client
- */
 class RequestDecoder
 {
     /**
      * @param string $response
+     *
      * @return string
      */
     public static function decode(string $response): string
     {
-        return stristr(stristr($response, "<s:"), "</s:Envelope>", true) . "</s:Envelope>";
+        return stristr(stristr($response, '<s:'), '</s:Envelope>', true).'</s:Envelope>';
     }
 }

--- a/src/GusApi/Client/SoapClient.php
+++ b/src/GusApi/Client/SoapClient.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace GusApi\Client;
+
+use SoapClient as BaseSoapClient;
 
 /**
  * Class SoapClient provides a client for the GUS server
- * @package GusApi\Client
  */
-class SoapClient extends \SoapClient
+class SoapClient extends BaseSoapClient
 {
     /**
      * @var resource
@@ -19,8 +21,9 @@ class SoapClient extends \SoapClient
 
     /**
      * SoapClient constructor.
-     * @param string $wsdl
-     * @param string $location
+     *
+     * @param string     $wsdl
+     * @param string     $location
      * @param array|null $options
      * @param array|null $contextOptions
      */
@@ -36,20 +39,20 @@ class SoapClient extends \SoapClient
     /**
      * Do request into regon server
      *
-     * @param string $request request
+     * @param string $request  request
      * @param string $location location
-     * @param string $action action
-     * @param int $version version
-     * @param int $one_way [optional] <p>
-     * If one_way is set to 1, this method returns nothing.
-     * Use this where a response is not expected.
-     * </p>
+     * @param string $action   action
+     * @param int    $version  version
+     * @param int    $one_way  [optional] <p>
+     *                         If one_way is set to 1, this method returns nothing.
+     *                         Use this where a response is not expected.
+     *                         </p>
+     *
      * @return string response
      */
     public function __doRequest($request, $location, $action, $version = SOAP_1_2, $one_way = null)
     {
-        $location = $this->location;
-        $response = parent::__doRequest($request, $location, $action, $version, $one_way);
+        $response = parent::__doRequest($request, $this->location, $action, $version, $one_way);
 
         return RequestDecoder::decode($response);
     }
@@ -62,12 +65,13 @@ class SoapClient extends \SoapClient
     public function __setHttpHeader(array $header)
     {
         $this->setContextOption([
-            'http' => $header
+            'http' => $header,
         ]);
     }
 
     /**
      * Set location
+     *
      * @param string $location
      */
     public function setLocation($location)
@@ -77,6 +81,7 @@ class SoapClient extends \SoapClient
 
     /**
      * Get location
+     *
      * @return string
      */
     public function getLocation()
@@ -88,6 +93,7 @@ class SoapClient extends \SoapClient
      * Create http context
      *
      * @param array|null $contextOptions
+     *
      * @return resource
      */
     private function createContext(array $contextOptions = null)

--- a/src/GusApi/Exception/InvalidReportTypeException.php
+++ b/src/GusApi/Exception/InvalidReportTypeException.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace GusApi\Exception;
 
 class InvalidReportTypeException extends \InvalidArgumentException
 {
-
 }

--- a/src/GusApi/Exception/InvalidSidException.php
+++ b/src/GusApi/Exception/InvalidSidException.php
@@ -4,5 +4,4 @@ namespace GusApi\Exception;
 
 class InvalidSidException extends \InvalidArgumentException
 {
-
 }

--- a/src/GusApi/Exception/InvalidSiloTypeException.php
+++ b/src/GusApi/Exception/InvalidSiloTypeException.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace GusApi\Exception;
 
 class InvalidSiloTypeException extends \InvalidArgumentException
 {
-
 }

--- a/src/GusApi/Exception/InvalidUserKeyException.php
+++ b/src/GusApi/Exception/InvalidUserKeyException.php
@@ -4,5 +4,4 @@ namespace GusApi\Exception;
 
 class InvalidUserKeyException extends \InvalidArgumentException
 {
-
 }

--- a/src/GusApi/Exception/NotFoundException.php
+++ b/src/GusApi/Exception/NotFoundException.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace GusApi\Exception;
 
 class NotFoundException extends \Exception
 {
-
 }

--- a/src/GusApi/GusApi.php
+++ b/src/GusApi/GusApi.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace GusApi;
 
 use GusApi\Adapter\AdapterInterface;
-use GusApi\Adapter\Soap\Exception\NoDataException;
 use GusApi\Adapter\Soap\SoapAdapter;
 use GusApi\Exception\InvalidUserKeyException;
 use GusApi\Exception\NotFoundException;
@@ -11,12 +11,12 @@ use GusApi\Exception\NotFoundException;
  * Class GusApi
  *
  * @package GusApi
+ *
  * @author Janusz Żukowicz <john_zuk@wp.pl>
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 class GusApi
 {
-
     /**
      * @var string user key
      */
@@ -35,7 +35,7 @@ class GusApi
     {
         $this->userKey = $userKey;
 
-        if ($adapter === null) {
+        if (null === $adapter) {
             $adapter = new SoapAdapter(
                 RegonConstantsInterface::BASE_WSDL_URL_TEST,
                 RegonConstantsInterface::BASE_WSDL_ADDRESS_TEST
@@ -81,6 +81,7 @@ class GusApi
      * Logout from regon server
      *
      * @param string $sid session id
+     *
      * @return bool logout status
      */
     public function logout($sid)
@@ -92,17 +93,19 @@ class GusApi
      * Tells whether the your status is login
      *
      * @param string $sid session id
+     *
      * @return bool login status
      */
     public function isLogged($sid)
     {
-        return (bool)$this->sessionStatus($sid);
+        return (bool) $this->sessionStatus($sid);
     }
 
     /**
      * Get actual data status
      *
      * @param string $sid session id
+     *
      * @return \DateTime data status date time value
      */
     public function dataStatus($sid)
@@ -140,13 +143,15 @@ class GusApi
      *
      * @param string $sid session id
      * @param string $nip NIP number
-     * @return SearchReport[] search subject information object
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[] search subject information object
      */
     public function getByNip($sid, $nip)
     {
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_NIP => $nip
+            RegonConstantsInterface::SEARCH_TYPE_NIP => $nip,
         ]);
     }
 
@@ -155,13 +160,15 @@ class GusApi
      *
      * @param $sid
      * @param $regon
-     * @return SearchReport[] search subject information object
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[] search subject information object
      */
     public function getByRegon($sid, $regon)
     {
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_REGON => $regon
+            RegonConstantsInterface::SEARCH_TYPE_REGON => $regon,
         ]);
     }
 
@@ -170,85 +177,95 @@ class GusApi
      *
      * @param $sid
      * @param $krs
-     * @return SearchReport[] search subject information object
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[] search subject information object
      */
     public function getByKrs($sid, $krs)
     {
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_KRS => $krs
+            RegonConstantsInterface::SEARCH_TYPE_KRS => $krs,
         ]);
     }
 
     /**
      * @param $sid
-     * @param array $nips Maxium quantity is 20.
-     * @return SearchReport[]
+     * @param array $nips maxium quantity is 20
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[]
      */
     public function getByNips($sid, array $nips)
     {
         if (count($nips) > 20) {
-            throw new \InvalidArgumentException("Too many NIP numbers. Maximum quantity is 20.");
+            throw new \InvalidArgumentException('Too many NIP numbers. Maximum quantity is 20.');
         }
         $nips = implode(',', $nips);
 
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_NIPS => $nips
+            RegonConstantsInterface::SEARCH_TYPE_NIPS => $nips,
         ]);
     }
 
     /**
      * @param $sid
-     * @param array $krses Maxium quantity is 20.
-     * @return SearchReport[]
+     * @param array $krses maxium quantity is 20
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[]
      */
     public function getByKrses($sid, array $krses)
     {
         if (count($krses) > 20) {
-            throw new \InvalidArgumentException("Too many KRS numbers. Maximum quantity is 20.");
+            throw new \InvalidArgumentException('Too many KRS numbers. Maximum quantity is 20.');
         }
         $krses = implode(',', $krses);
 
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_KRSES => $krses
+            RegonConstantsInterface::SEARCH_TYPE_KRSES => $krses,
         ]);
     }
 
     /**
      * @param $sid
-     * @param array $regons Maxium quantity is 20.
-     * @return SearchReport[]
+     * @param array $regons maxium quantity is 20
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[]
      */
     public function getByRegons9($sid, array $regons)
     {
         if (count($regons) > 20) {
-            throw new \InvalidArgumentException("Too many REGON numbers. Maximum quantity is 20.");
+            throw new \InvalidArgumentException('Too many REGON numbers. Maximum quantity is 20.');
         }
         $regons = implode(',', $regons);
 
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_REGONS_9 => $regons
+            RegonConstantsInterface::SEARCH_TYPE_REGONS_9 => $regons,
         ]);
     }
 
     /**
      * @param $sid
-     * @param array $regons Maxium quantity is 20.
-     * @return SearchReport[]
+     * @param array $regons maxium quantity is 20
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[]
      */
     public function getByregons14($sid, array $regons)
     {
         if (count($regons) > 20) {
-            throw new \InvalidArgumentException("Too many REGON numbers. Maximum quantity is 20.");
+            throw new \InvalidArgumentException('Too many REGON numbers. Maximum quantity is 20.');
         }
         $regons = implode(',', $regons);
 
         return $this->search($sid, [
-            RegonConstantsInterface::SEARCH_TYPE_REGONS_14 => $regons
+            RegonConstantsInterface::SEARCH_TYPE_REGONS_14 => $regons,
         ]);
     }
 
@@ -256,6 +273,7 @@ class GusApi
      * @param $sid
      * @param SearchReport $searchReport
      * @param $reportType
+     *
      * @return mixed|\SimpleXMLElement
      */
     public function getFullReport($sid, SearchReport $searchReport, $reportType)
@@ -269,6 +287,7 @@ class GusApi
      * Get get message about search if you don't get data
      *
      * @param $sid
+     *
      * @return string
      */
     public function getResultSearchMessage($sid)
@@ -283,7 +302,9 @@ class GusApi
 
     /**
      * Return message code if search not found record
+     *
      * @param $sid
+     *
      * @return int
      */
     public function getMessageCode($sid)
@@ -293,7 +314,9 @@ class GusApi
 
     /**
      * Return message text id search not found record
+     *
      * @param $sid
+     *
      * @return string
      */
     public function getMessage($sid)
@@ -303,6 +326,9 @@ class GusApi
 
     /**
      * Return session status
+     *
+     * @param mixed $sid
+     *
      * @return int
      */
     public function sessionStatus($sid)
@@ -311,19 +337,18 @@ class GusApi
     }
 
     /**
-     * @param $sid
-     * @param array $searchData
-     * @return SearchReport[]
+     * @param string $sid
+     * @param array  $searchData
+     *
      * @throws NotFoundException
+     *
+     * @return SearchReport[]
      */
-    private function search($sid, array $searchData)
+    private function search(string $sid, array $searchData): array
     {
         $result = [];
-        try {
-            $response = $this->adapter->search($sid, $searchData);
-        } catch (NoDataException $e) {
-            throw new NotFoundException(sprintf("Not found subject"));
-        }
+        $response = $this->adapter->search($sid, $searchData);
+
         foreach ($response as $report) {
             $result[] = new SearchReport($report);
         }

--- a/src/GusApi/RegonConstantsInterface.php
+++ b/src/GusApi/RegonConstantsInterface.php
@@ -1,13 +1,14 @@
 <?php
+
 namespace GusApi;
 
 interface RegonConstantsInterface
 {
     const BASE_WSDL_URL_TEST = 'https://wyszukiwarkaregontest.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl.xsd';
-    const BASE_WSDL_ADDRESS_TEST =  'https://Wyszukiwarkaregontest.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc';
+    const BASE_WSDL_ADDRESS_TEST = 'https://Wyszukiwarkaregontest.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc';
 
     const BASE_WSDL_URL = 'https://wyszukiwarkaregontest.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl.xsd';
-    const BASE_WSDL_ADDRESS =  'https://wyszukiwarkaregon.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc';
+    const BASE_WSDL_ADDRESS = 'https://wyszukiwarkaregon.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc';
 
     const PARAM_USER_KEY = 'pKluczUzytkownika';
     const PARAM_SESSION_ID = 'pIdentyfikatorSesji';
@@ -17,14 +18,14 @@ interface RegonConstantsInterface
     const PARAM_REPORT_NAME = 'pNazwaRaportu';
     const PARAM_PARAM_NAME = 'pNazwaParametru';
 
-    const SEARCH_TYPE_NIP  = 'Nip';
-    const SEARCH_TYPE_KRS  = 'Krs';
+    const SEARCH_TYPE_NIP = 'Nip';
+    const SEARCH_TYPE_KRS = 'Krs';
     const SEARCH_TYPE_REGON = 'Regon';
 
-    const SEARCH_TYPE_NIPS  = 'Nipy';
+    const SEARCH_TYPE_NIPS = 'Nipy';
     const SEARCH_TYPE_KRSES = 'Krsy';
-    const SEARCH_TYPE_REGONS_9  = 'Regony9zn';
-    const SEARCH_TYPE_REGONS_14  = 'Regony14zn';
+    const SEARCH_TYPE_REGONS_9 = 'Regony9zn';
+    const SEARCH_TYPE_REGONS_14 = 'Regony14zn';
 
     const PARAM_STATUS_DATE_STATE = 'StanDanych';
     const PARAM_MESSAGE_CODE = 'KomunikatKod';

--- a/src/GusApi/ReportTypeMapper.php
+++ b/src/GusApi/ReportTypeMapper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GusApi;
 
 use GusApi\Exception\InvalidReportTypeException;
@@ -7,14 +8,17 @@ use GusApi\Exception\InvalidSiloTypeException;
 
 /**
  * Class ReportTypeMapper
+ *
  * @package GusApi
  */
 class ReportTypeMapper
 {
     /**
      * @param SearchReport $report
+     *
      * @throws InvalidReportTypeException
      * @throws InvalidSiloTypeException
+     *
      * @return string
      */
     public function getReportType(SearchReport $report): string
@@ -22,7 +26,7 @@ class ReportTypeMapper
         $method = 'type'.ucfirst($report->getType());
 
         if (!method_exists($this, $method)) {
-            throw new InvalidReportTypeException(sprintf("Invalid report type: %s", $report->getType()));
+            throw new InvalidReportTypeException(sprintf('Invalid report type: %s', $report->getType()));
         }
 
         return $this->$method($report->getSilo());
@@ -30,6 +34,7 @@ class ReportTypeMapper
 
     /**
      * @param int $silo
+     *
      * @return string
      */
     protected function typeP(int $silo): string
@@ -39,6 +44,7 @@ class ReportTypeMapper
 
     /**
      * @param int $silo
+     *
      * @return string
      */
     protected function typeF(int $silo): string
@@ -51,7 +57,7 @@ class ReportTypeMapper
         ];
 
         if (!array_key_exists($silo, $siloMapper)) {
-            throw new InvalidSidException(sprintf("Invalid silo type: %s", $silo));
+            throw new InvalidSidException(sprintf('Invalid silo type: %s', $silo));
         }
 
         return $siloMapper[$silo];
@@ -59,6 +65,7 @@ class ReportTypeMapper
 
     /**
      * @param int $silo
+     *
      * @return string
      */
     protected function typeLp(int $silo): string
@@ -68,6 +75,7 @@ class ReportTypeMapper
 
     /**
      * @param int $silo
+     *
      * @return string
      */
     protected function typeLf(int $silo): string

--- a/src/GusApi/ReportTypes.php
+++ b/src/GusApi/ReportTypes.php
@@ -1,18 +1,20 @@
 <?php
+
 namespace GusApi;
 
 /**
  * All report types
  * Class ReportTypes
+ *
  * @package GusApi
  */
 final class ReportTypes
 {
     const REPORT_ACTIVITY_PHYSIC_PERSON = 'PublDaneRaportFizycznaOsoba';
     const REPORT_ACTIVITY_PHYSIC_CEIDG = 'PublDaneRaportDzialalnoscFizycznejCeidg';
-    
+
     /**
-     * @deprecated Use ReportTypes::REPORT_ACTIVITY_PHYSIC_CEIDG instead.
+     * @deprecated use ReportTypes::REPORT_ACTIVITY_PHYSIC_CEIDG instead
      */
     const REPORT_ACTIVITY_PHYSIC_CEGID = 'PublDaneRaportDzialalnoscFizycznejCeidg';
     const REPORT_ACTIVITY_PHYSIC_AGRO = 'PublDaneRaportDzialalnoscFizycznejRolnicza';

--- a/src/GusApi/SearchReport.php
+++ b/src/GusApi/SearchReport.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace GusApi;
 
 /**
  * Class SearchReport
+ *
  * @package GusApi
  */
 class SearchReport implements \JsonSerializable
@@ -72,21 +74,22 @@ class SearchReport implements \JsonSerializable
 
     /**
      * SearchReport constructor.
+     *
      * @param $data
      */
     public function __construct($data)
     {
-        $this->regon = (string)$data->Regon;
-        $this->name = (string)$data->Nazwa;
-        $this->province = (string)$data->Wojewodztwo;
-        $this->district = (string)$data->Powiat;
-        $this->community = (string)$data->Gmina;
-        $this->city = (string)$data->Miejscowosc;
-        $this->zipCode = (string)$data->KodPocztowy;
-        $this->street = (string)$data->Ulica;
-        $this->type = $this->makeType((string)$data->Typ);
+        $this->regon = (string) $data->Regon;
+        $this->name = (string) $data->Nazwa;
+        $this->province = (string) $data->Wojewodztwo;
+        $this->district = (string) $data->Powiat;
+        $this->community = (string) $data->Gmina;
+        $this->city = (string) $data->Miejscowosc;
+        $this->zipCode = (string) $data->KodPocztowy;
+        $this->street = (string) $data->Ulica;
+        $this->type = $this->makeType((string) $data->Typ);
         $this->regon14 = $this->makeRegon14($this->regon);
-        $this->silo = (int)$data->SilosID;
+        $this->silo = (int) $data->SilosID;
     }
 
     /**
@@ -197,29 +200,31 @@ class SearchReport implements \JsonSerializable
 
     /**
      * @param string $regon
+     *
      * @return string
      */
     private function makeRegon14($regon)
     {
-        return str_pad($regon, 14, "0");
+        return str_pad($regon, 14, '0');
     }
 
     /**
      * @param string $type
+     *
      * @return string
      */
     private function makeType($type)
     {
         return trim(strtolower($type));
     }
-    
+
     /**
      * @return array
      */
     public function jsonSerialize()
     {
         $vars = get_object_vars($this);
-    
+
         return $vars;
     }
 }

--- a/tests/Integration/GusApiTest.php
+++ b/tests/Integration/GusApiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace GusApi\Tests\Integration;
+
+use GusApi\Exception\NotFoundException;
+use GusApi\GusApi;
+use GusApi\SearchReport;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group risky
+ */
+class GusApiTest extends TestCase
+{
+    /**
+     * @var GusApi
+     */
+    protected static $apiClient;
+
+    /**
+     * @var string
+     */
+    protected static $sid;
+
+    public static function setUpBeforeClass()
+    {
+        self::$apiClient = new GusApi('abcde12345abcde12345');
+        self::$sid = self::$apiClient->login();
+    }
+
+    public function testGetExampleCompanyByNip()
+    {
+        $result = self::$apiClient->getByNip(self::$sid, '7740001454');
+        $this->assertCount(1, $result);
+        $this->assertValidExampleCompany($result[0]);
+    }
+
+    public function testGetByInvalidNip()
+    {
+        $this->expectException(NotFoundException::class);
+        self::$apiClient->getByNip(self::$sid, '0123456789');
+    }
+
+    public function testGetExampleCompanyByRegon()
+    {
+        $result = self::$apiClient->getByRegon(self::$sid, '610188201');
+        $this->assertCount(1, $result);
+        $this->assertValidExampleCompany($result[0]);
+    }
+
+    public function testGetExampleCompanyByKrs()
+    {
+        $result = self::$apiClient->getByKrs(self::$sid, '0000028860');
+        $this->assertCount(1, $result);
+        $this->assertValidExampleCompany($result[0]);
+    }
+
+    protected function assertValidExampleCompany(SearchReport $report)
+    {
+        $this->assertSame('61018820100000', $report->getRegon());
+        $this->assertSame('61018820100000', $report->getRegon14());
+        $this->assertSame('POLSKI KONCERN NAFTOWY ORLEN SPÓŁKA AKCYJNA', $report->getName());
+        $this->assertSame('MAZOWIECKIE', $report->getProvince());
+        $this->assertSame('m. Płock', $report->getDistrict());
+        $this->assertSame('M. Płock', $report->getCommunity());
+        $this->assertSame('Płock', $report->getCity());
+        $this->assertSame('09-411', $report->getZipCode());
+        $this->assertSame('ul. Test-Wilcza', $report->getStreet());
+        $this->assertSame(SearchReport::TYPE_JURIDICAL_PERSON, $report->getType());
+        $this->assertSame(6, $report->getSilo());
+    }
+}

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -5,7 +5,7 @@ namespace GusApi\Tests;
 use GusApi\GusApi;
 use PHPUnit\Framework\TestCase;
 
-class GusApiTest extends TestCase
+class LoginTest extends TestCase
 {
     public function testLoginGus()
     {


### PR DESCRIPTION
- Dodano i uruchomiono PHP-CS-Fixer
- Dodano proste testy integracyjne (później należałby zamockować przykładowe odpowiedzi)
- Zależności zostały przeniesione do `require-dev`, ponieważ nie są potrzebne przy korzystaniu z biblioteki, a jedynie w jej rozwijaniu i testach.