### PR TITLE
`GusApi::getFullReport()` powinien zwracać wiele pozycji `<dane />`

### DIFF
--- a/src/GusApi/GusApi.php
+++ b/src/GusApi/GusApi.php
@@ -267,9 +267,9 @@ class GusApi
      * @param SearchReport $searchReport
      * @param string       $reportType
      *
-     * @return \SimpleXMLElement
+     * @return array[]
      */
-    public function getFullReport(SearchReport $searchReport, string $reportType): \SimpleXMLElement
+    public function getFullReport(SearchReport $searchReport, string $reportType): array
     {
         $result = $this->apiClient->getFullReport(
             new GetFullReport($searchReport->getRegon14(), $reportType),

--- a/src/GusApi/Type/Response/GetFullReportResponse.php
+++ b/src/GusApi/Type/Response/GetFullReportResponse.php
@@ -5,24 +5,24 @@ namespace GusApi\Type\Response;
 class GetFullReportResponse
 {
     /**
-     * @var \SimpleXMLElement
+     * @var array[]
      */
     public $report;
 
     /**
      * GetFullReportResponse constructor.
      *
-     * @param \SimpleXMLElement $report
+     * @param array[] $report
      */
-    public function __construct(\SimpleXMLElement $report)
+    public function __construct(array $report = [])
     {
         $this->report = $report;
     }
 
     /**
-     * @return \SimpleXMLElement
+     * @return array[]
      */
-    public function getReport(): \SimpleXMLElement
+    public function getReport(): array
     {
         return $this->report;
     }

--- a/src/GusApi/Util/FullReportResponseDecoder.php
+++ b/src/GusApi/Util/FullReportResponseDecoder.php
@@ -17,14 +17,24 @@ class FullReportResponseDecoder
      */
     public static function decode(GetFullReportResponseRaw $fullReportResponseRaw): GetFullReportResponse
     {
+        $elements = [];
+
         if ('' === $fullReportResponseRaw->getDanePobierzPelnyRaportResult()) {
-            return new GetFullReportResponse(new \SimpleXMLElement('<data></data>'));
+            return new GetFullReportResponse($elements);
         }
 
         try {
             $xmlElementsResponse = new \SimpleXMLElement($fullReportResponseRaw->getDanePobierzPelnyRaportResult());
 
-            return new GetFullReportResponse($xmlElementsResponse->dane);
+            foreach ($xmlElementsResponse->dane as $resultData) {
+                $element = [];
+                foreach ($resultData as $key => $item) {
+                    $element[$key] = (string)$item;
+                }
+                $elements[] = $element;
+            }
+
+            return new GetFullReportResponse($elements);
         } catch (\Exception $e) {
             throw new InvalidServerResponseException('Invalid server response');
         }

--- a/src/GusApi/Util/FullReportResponseDecoder.php
+++ b/src/GusApi/Util/FullReportResponseDecoder.php
@@ -29,7 +29,7 @@ class FullReportResponseDecoder
             foreach ($xmlElementsResponse->dane as $resultData) {
                 $element = [];
                 foreach ($resultData as $key => $item) {
-                    $element[$key] = (string)$item;
+                    $element[$key] = (string) $item;
                 }
                 $elements[] = $element;
             }

--- a/tests/Client/GusApiClientTest.php
+++ b/tests/Client/GusApiClientTest.php
@@ -121,11 +121,87 @@ class GusApiClientTest extends TestCase
         $this->expectSoapCall(
             'DanePobierzPelnyRaport',
             [$searchData],
-            new GetFullReportResponseRaw('<report>'.$searchRawResponse.'</report>')
+            new GetFullReportResponseRaw($searchRawResponse)
         );
 
         $this->assertEquals(
-            new GetFullReportResponse(new \SimpleXMLElement($searchRawResponse)),
+            new GetFullReportResponse([
+                [
+                    'fiz_regon9' => '666666666',
+                    'fiz_nazwa' => 'NIEPUBLICZNY ZAKŁAD OPIEKI ZDROWOTNEJ xxxxxxxxxxxxx',
+                    'fiz_nazwaSkrocona' => '',
+                    'fiz_dataPowstania' => '1993-03-20',
+                    'fiz_dataRozpoczeciaDzialalnosci' => '1999-10-20',
+                    'fiz_dataWpisuDoREGONDzialalnosci' => '',
+                    'fiz_dataZawieszeniaDzialalnosci' => '',
+                    'fiz_dataWznowieniaDzialalnosci' => '',
+                    'fiz_dataZaistnieniaZmianyDzialalnosci' => '2011-08-16',
+                    'fiz_dataZakonczeniaDzialalnosci' => '',
+                    'fiz_dataSkresleniazRegonDzialalnosci' => '',
+                    'fiz_adSiedzKraj_Symbol' => '',
+                    'fiz_adSiedzWojewodztwo_Symbol' => '30',
+                    'fiz_adSiedzPowiat_Symbol' => '22',
+                    'fiz_adSiedzGmina_Symbol' => '059',
+                    'fiz_adSiedzKodPocztowy' => '69000',
+                    'fiz_adSiedzMiejscowoscPoczty_Symbol' => '0198380',
+                    'fiz_adSiedzMiejscowosc_Symbol' => '0198380',
+                    'fiz_adSiedzUlica_Symbol' => '1240',
+                    'fiz_adSiedzNumerNieruchomosci' => '99',
+                    'fiz_adSiedzNumerLokalu' => '',
+                    'fiz_adSiedzNietypoweMiejsceLokalizacji' => '',
+                    'fiz_numerTelefonu' => '',
+                    'fiz_numerWewnetrznyTelefonu' => '',
+                    'fiz_numerFaksu' => '9999999999',
+                    'fiz_adresEmail' => '',
+                    'fiz_adresStronyinternetowej' => '',
+                    'fiz_adresEmail2' => '',
+                    'fiz_adSiedzKraj_Nazwa' => '',
+                    'fiz_adSiedzWojewodztwo_Nazwa' => 'WIELKOPOLSKIE',
+                    'fiz_adSiedzPowiat_Nazwa' => 'xxxxxxxxxx',
+                    'fiz_adSiedzGmina_Nazwa' => 'Yyyyyyyy',
+                    'fiz_adSiedzMiejscowosc_Nazwa' => 'Yyyyyyyy',
+                    'fiz_adSiedzMiejscowoscPoczty_Nazwa' => 'Yyyyyyyy',
+                    'fiz_adSiedzUlica_Nazwa' => 'ul. Adama Mickiewicza',
+                    'fizP_dataWpisuDoRejestruEwidencji' => '',
+                    'fizP_numerwRejestrzeEwidencji' => '',
+                    'fizP_OrganRejestrowy_Symbol' => '',
+                    'fizP_OrganRejestrowy_Nazwa' => '',
+                    'fizP_RodzajRejestru_Symbol' => '099',
+                    'fizP_RodzajRejestru_Nazwa' => 'PODMIOTY NIE PODLEGAJĄCE WPISOM DO REJESTRU LUB EWIDENCJI',
+                ],
+            ]),
+            $this->gusApiClient->getFullReport($searchData, '1234567890')
+        );
+    }
+
+    public function testGetFullReportMultiple()
+    {
+        $searchRawResponse = file_get_contents(__DIR__.'/../resources/response/fullSearchMultipleResponse.xsd');
+        $searchData = new GetFullReport('00112233445566', 'PublDaneRaportDzialalnosciPrawnej');
+        $this->expectSoapCall(
+            'DanePobierzPelnyRaport',
+            [$searchData],
+            new GetFullReportResponseRaw($searchRawResponse)
+        );
+
+        $this->assertEquals(
+            new GetFullReportResponse([
+                [
+                    'praw_pkdKod' => '7430Z',
+                    'praw_pkdNazwa' => 'DZIAŁALNOŚĆ ZWIĄZANA Z TŁUMACZENIAMI',
+                    'praw_pkdPrzewazajace' => '0',
+                ],
+                [
+                    'praw_pkdKod' => '7420Z',
+                    'praw_pkdNazwa' => 'DZIAŁALNOŚĆ FOTOGRAFICZNA',
+                    'praw_pkdPrzewazajace' => '0',
+                ],
+                [
+                    'praw_pkdKod' => '7410Z',
+                    'praw_pkdNazwa' => 'DZIAŁALNOŚĆ W ZAKRESIE SPECJALISTYCZNEGO PROJEKTOWANIA',
+                    'praw_pkdPrzewazajace' => '1',
+                ],
+            ]),
             $this->gusApiClient->getFullReport($searchData, '1234567890')
         );
     }

--- a/tests/GusApiTest.php
+++ b/tests/GusApiTest.php
@@ -117,13 +117,56 @@ class GusApiTest extends TestCase
             ->expects($this->once())
             ->method('getFullReport')
             ->with(new GetFullReport('61018820100000', 'PublDaneRaportPrawna'), $this->sessionId)
-            ->willReturn(new GetFullReportResponse(new \SimpleXMLElement($response)))
+            ->willReturn(new GetFullReportResponse([
+                [
+                    'fiz_regon9' => '666666666',
+                    'fiz_nazwa' => 'NIEPUBLICZNY ZAKŁAD OPIEKI ZDROWOTNEJ xxxxxxxxxxxxx',
+                    'fiz_nazwaSkrocona' => '',
+                    'fiz_dataPowstania' => '1993-03-20',
+                    'fiz_dataRozpoczeciaDzialalnosci' => '1999-10-20',
+                    'fiz_dataWpisuDoREGONDzialalnosci' => '',
+                    'fiz_dataZawieszeniaDzialalnosci' => '',
+                    'fiz_dataWznowieniaDzialalnosci' => '',
+                    'fiz_dataZaistnieniaZmianyDzialalnosci' => '2011-08-16',
+                    'fiz_dataZakonczeniaDzialalnosci' => '',
+                    'fiz_dataSkresleniazRegonDzialalnosci' => '',
+                    'fiz_adSiedzKraj_Symbol' => '',
+                    'fiz_adSiedzWojewodztwo_Symbol' => '30',
+                    'fiz_adSiedzPowiat_Symbol' => '22',
+                    'fiz_adSiedzGmina_Symbol' => '059',
+                    'fiz_adSiedzKodPocztowy' => '69000',
+                    'fiz_adSiedzMiejscowoscPoczty_Symbol' => '0198380',
+                    'fiz_adSiedzMiejscowosc_Symbol' => '0198380',
+                    'fiz_adSiedzUlica_Symbol' => '1240',
+                    'fiz_adSiedzNumerNieruchomosci' => '99',
+                    'fiz_adSiedzNumerLokalu' => '',
+                    'fiz_adSiedzNietypoweMiejsceLokalizacji' => '',
+                    'fiz_numerTelefonu' => '',
+                    'fiz_numerWewnetrznyTelefonu' => '',
+                    'fiz_numerFaksu' => '9999999999',
+                    'fiz_adresEmail' => '',
+                    'fiz_adresStronyinternetowej' => '',
+                    'fiz_adresEmail2' => '',
+                    'fiz_adSiedzKraj_Nazwa' => '',
+                    'fiz_adSiedzWojewodztwo_Nazwa' => 'WIELKOPOLSKIE',
+                    'fiz_adSiedzPowiat_Nazwa' => 'xxxxxxxxxx',
+                    'fiz_adSiedzGmina_Nazwa' => 'Yyyyyyyy',
+                    'fiz_adSiedzMiejscowosc_Nazwa' => 'Yyyyyyyy',
+                    'fiz_adSiedzMiejscowoscPoczty_Nazwa' => 'Yyyyyyyy',
+                    'fiz_adSiedzUlica_Nazwa' => 'ul. Adama Mickiewicza',
+                    'fizP_dataWpisuDoRejestruEwidencji' => '',
+                    'fizP_numerwRejestrzeEwidencji' => '',
+                    'fizP_OrganRejestrowy_Symbol' => '',
+                    'fizP_OrganRejestrowy_Nazwa' => '',
+                    'fizP_RodzajRejestru_Symbol' => '099',
+                    'fizP_RodzajRejestru_Nazwa' => 'PODMIOTY NIE PODLEGAJĄCE WPISOM DO REJESTRU LUB EWIDENCJI',
+                ],
+            ]))
         ;
 
         $this->login();
         $fullReport = $this->api->getFullReport($searchReport, ReportTypes::REPORT_PUBLIC_LAW);
-        $this->assertInstanceOf(\SimpleXMLElement::class, $fullReport);
-        $this->assertXmlStringEqualsXmlString($response, $fullReport->asXML());
+        $this->assertInternalType('array', $fullReport);
     }
 
     public function testTooManyNipsRaisesAnException()

--- a/tests/Integration/GusApiTest.php
+++ b/tests/Integration/GusApiTest.php
@@ -96,8 +96,10 @@ class GusApiTest extends TestCase
         $report = $this->createMock(SearchReport::class);
         $report->method('getRegon14')->willReturn('61018820100000');
         $result = self::$apiClient->getFullReport($report, ReportTypes::REPORT_PUBLIC_LAW);
-        $this->assertEquals('61018820100000', $result->praw_regon14);
-        $this->assertEquals('1993-07-01', $result->praw_dataPowstania);
+        $this->assertInternalType('array', $result);
+        $this->assertInternalType('array', $result[0]);
+        $this->assertEquals('61018820100000', $result[0]['praw_regon14']);
+        $this->assertEquals('1993-07-01', $result[0]['praw_dataPowstania']);
     }
 
     public function testInvalidKey()

--- a/tests/Util/FullReportResponseDecoderTest.php
+++ b/tests/Util/FullReportResponseDecoderTest.php
@@ -15,17 +15,61 @@ class FullReportResponseDecoderTest extends TestCase
         $reportDecoded = FullReportResponseDecoder::decode($rawReport);
 
         $this->assertInstanceOf(GetFullReportResponse::class, $reportDecoded);
-        $this->assertEquals(new \SimpleXMLElement('<data></data>'), $reportDecoded->getReport());
+        $this->assertEquals([], $reportDecoded->getReport());
     }
 
     public function testDecodeWithValidXMLObject()
     {
         $content = file_get_contents(__DIR__.'/../resources/response/fullSearchResponse.xsd');
-        $rawReport = new GetFullReportResponseRaw('<result>'.$content.'</result>');
+        $rawReport = new GetFullReportResponseRaw($content);
         $reportDecoded = FullReportResponseDecoder::decode($rawReport);
 
         $this->assertInstanceOf(GetFullReportResponse::class, $reportDecoded);
-        $this->assertEquals(new \SimpleXMLElement($content), $reportDecoded->getReport());
+        $this->assertEquals([
+            [
+                'fiz_regon9' => '666666666',
+                'fiz_nazwa' => 'NIEPUBLICZNY ZAKŁAD OPIEKI ZDROWOTNEJ xxxxxxxxxxxxx',
+                'fiz_nazwaSkrocona' => '',
+                'fiz_dataPowstania' => '1993-03-20',
+                'fiz_dataRozpoczeciaDzialalnosci' => '1999-10-20',
+                'fiz_dataWpisuDoREGONDzialalnosci' => '',
+                'fiz_dataZawieszeniaDzialalnosci' => '',
+                'fiz_dataWznowieniaDzialalnosci' => '',
+                'fiz_dataZaistnieniaZmianyDzialalnosci' => '2011-08-16',
+                'fiz_dataZakonczeniaDzialalnosci' => '',
+                'fiz_dataSkresleniazRegonDzialalnosci' => '',
+                'fiz_adSiedzKraj_Symbol' => '',
+                'fiz_adSiedzWojewodztwo_Symbol' => '30',
+                'fiz_adSiedzPowiat_Symbol' => '22',
+                'fiz_adSiedzGmina_Symbol' => '059',
+                'fiz_adSiedzKodPocztowy' => '69000',
+                'fiz_adSiedzMiejscowoscPoczty_Symbol' => '0198380',
+                'fiz_adSiedzMiejscowosc_Symbol' => '0198380',
+                'fiz_adSiedzUlica_Symbol' => '1240',
+                'fiz_adSiedzNumerNieruchomosci' => '99',
+                'fiz_adSiedzNumerLokalu' => '',
+                'fiz_adSiedzNietypoweMiejsceLokalizacji' => '',
+                'fiz_numerTelefonu' => '',
+                'fiz_numerWewnetrznyTelefonu' => '',
+                'fiz_numerFaksu' => '9999999999',
+                'fiz_adresEmail' => '',
+                'fiz_adresStronyinternetowej' => '',
+                'fiz_adresEmail2' => '',
+                'fiz_adSiedzKraj_Nazwa' => '',
+                'fiz_adSiedzWojewodztwo_Nazwa' => 'WIELKOPOLSKIE',
+                'fiz_adSiedzPowiat_Nazwa' => 'xxxxxxxxxx',
+                'fiz_adSiedzGmina_Nazwa' => 'Yyyyyyyy',
+                'fiz_adSiedzMiejscowosc_Nazwa' => 'Yyyyyyyy',
+                'fiz_adSiedzMiejscowoscPoczty_Nazwa' => 'Yyyyyyyy',
+                'fiz_adSiedzUlica_Nazwa' => 'ul. Adama Mickiewicza',
+                'fizP_dataWpisuDoRejestruEwidencji' => '',
+                'fizP_numerwRejestrzeEwidencji' => '',
+                'fizP_OrganRejestrowy_Symbol' => '',
+                'fizP_OrganRejestrowy_Nazwa' => '',
+                'fizP_RodzajRejestru_Symbol' => '099',
+                'fizP_RodzajRejestru_Nazwa' => 'PODMIOTY NIE PODLEGAJĄCE WPISOM DO REJESTRU LUB EWIDENCJI',
+            ],
+        ], $reportDecoded->getReport());
     }
 
     /**

--- a/tests/resources/response/fullSearchMultipleResponse.xsd
+++ b/tests/resources/response/fullSearchMultipleResponse.xsd
@@ -1,0 +1,17 @@
+<root>
+    <dane>
+        <praw_pkdKod>7430Z</praw_pkdKod>
+        <praw_pkdNazwa>DZIAŁALNOŚĆ ZWIĄZANA Z TŁUMACZENIAMI</praw_pkdNazwa>
+        <praw_pkdPrzewazajace>0</praw_pkdPrzewazajace>
+    </dane>
+    <dane>
+        <praw_pkdKod>7420Z</praw_pkdKod>
+        <praw_pkdNazwa>DZIAŁALNOŚĆ FOTOGRAFICZNA</praw_pkdNazwa>
+        <praw_pkdPrzewazajace>0</praw_pkdPrzewazajace>
+    </dane>
+    <dane>
+        <praw_pkdKod>7410Z</praw_pkdKod>
+        <praw_pkdNazwa>DZIAŁALNOŚĆ W ZAKRESIE SPECJALISTYCZNEGO PROJEKTOWANIA</praw_pkdNazwa>
+        <praw_pkdPrzewazajace>1</praw_pkdPrzewazajace>
+    </dane>
+</root>

--- a/tests/resources/response/fullSearchResponse.xsd
+++ b/tests/resources/response/fullSearchResponse.xsd
@@ -1,43 +1,45 @@
-<dane>
-    <fiz_regon9>666666666</fiz_regon9>
-    <fiz_nazwa>NIEPUBLICZNY ZAKŁAD OPIEKI ZDROWOTNEJ xxxxxxxxxxxxx</fiz_nazwa>
-    <fiz_nazwaSkrocona />
-    <fiz_dataPowstania>1993-03-20</fiz_dataPowstania>
-    <fiz_dataRozpoczeciaDzialalnosci>1999-10-20</fiz_dataRozpoczeciaDzialalnosci>
-    <fiz_dataWpisuDoREGONDzialalnosci />
-    <fiz_dataZawieszeniaDzialalnosci />
-    <fiz_dataWznowieniaDzialalnosci />
-    <fiz_dataZaistnieniaZmianyDzialalnosci>2011-08-16</fiz_dataZaistnieniaZmianyDzialalnosci>
-    <fiz_dataZakonczeniaDzialalnosci />
-    <fiz_dataSkresleniazRegonDzialalnosci />
-    <fiz_adSiedzKraj_Symbol />
-    <fiz_adSiedzWojewodztwo_Symbol>30</fiz_adSiedzWojewodztwo_Symbol>
-    <fiz_adSiedzPowiat_Symbol>22</fiz_adSiedzPowiat_Symbol>
-    <fiz_adSiedzGmina_Symbol>059</fiz_adSiedzGmina_Symbol>
-    <fiz_adSiedzKodPocztowy>69000</fiz_adSiedzKodPocztowy>
-    <fiz_adSiedzMiejscowoscPoczty_Symbol>0198380</fiz_adSiedzMiejscowoscPoczty_Symbol>
-    <fiz_adSiedzMiejscowosc_Symbol>0198380</fiz_adSiedzMiejscowosc_Symbol>
-    <fiz_adSiedzUlica_Symbol>1240</fiz_adSiedzUlica_Symbol>
-    <fiz_adSiedzNumerNieruchomosci>99</fiz_adSiedzNumerNieruchomosci>
-    <fiz_adSiedzNumerLokalu />
-    <fiz_adSiedzNietypoweMiejsceLokalizacji />
-    <fiz_numerTelefonu />
-    <fiz_numerWewnetrznyTelefonu />
-    <fiz_numerFaksu>9999999999</fiz_numerFaksu>
-    <fiz_adresEmail />
-    <fiz_adresStronyinternetowej />
-    <fiz_adresEmail2 />
-    <fiz_adSiedzKraj_Nazwa />
-    <fiz_adSiedzWojewodztwo_Nazwa>WIELKOPOLSKIE</fiz_adSiedzWojewodztwo_Nazwa>
-    <fiz_adSiedzPowiat_Nazwa>xxxxxxxxxx</fiz_adSiedzPowiat_Nazwa>
-    <fiz_adSiedzGmina_Nazwa>Yyyyyyyy</fiz_adSiedzGmina_Nazwa>
-    <fiz_adSiedzMiejscowosc_Nazwa>Yyyyyyyy</fiz_adSiedzMiejscowosc_Nazwa>
-    <fiz_adSiedzMiejscowoscPoczty_Nazwa>Yyyyyyyy</fiz_adSiedzMiejscowoscPoczty_Nazwa>
-    <fiz_adSiedzUlica_Nazwa>ul. Adama Mickiewicza</fiz_adSiedzUlica_Nazwa>
-    <fizP_dataWpisuDoRejestruEwidencji />
-    <fizP_numerwRejestrzeEwidencji />
-    <fizP_OrganRejestrowy_Symbol />
-    <fizP_OrganRejestrowy_Nazwa />
-    <fizP_RodzajRejestru_Symbol>099</fizP_RodzajRejestru_Symbol>
-    <fizP_RodzajRejestru_Nazwa>PODMIOTY NIE PODLEGAJĄCE WPISOM DO REJESTRU LUB EWIDENCJI</fizP_RodzajRejestru_Nazwa>
-</dane>
+<root>
+    <dane>
+        <fiz_regon9>666666666</fiz_regon9>
+        <fiz_nazwa>NIEPUBLICZNY ZAKŁAD OPIEKI ZDROWOTNEJ xxxxxxxxxxxxx</fiz_nazwa>
+        <fiz_nazwaSkrocona />
+        <fiz_dataPowstania>1993-03-20</fiz_dataPowstania>
+        <fiz_dataRozpoczeciaDzialalnosci>1999-10-20</fiz_dataRozpoczeciaDzialalnosci>
+        <fiz_dataWpisuDoREGONDzialalnosci />
+        <fiz_dataZawieszeniaDzialalnosci />
+        <fiz_dataWznowieniaDzialalnosci />
+        <fiz_dataZaistnieniaZmianyDzialalnosci>2011-08-16</fiz_dataZaistnieniaZmianyDzialalnosci>
+        <fiz_dataZakonczeniaDzialalnosci />
+        <fiz_dataSkresleniazRegonDzialalnosci />
+        <fiz_adSiedzKraj_Symbol />
+        <fiz_adSiedzWojewodztwo_Symbol>30</fiz_adSiedzWojewodztwo_Symbol>
+        <fiz_adSiedzPowiat_Symbol>22</fiz_adSiedzPowiat_Symbol>
+        <fiz_adSiedzGmina_Symbol>059</fiz_adSiedzGmina_Symbol>
+        <fiz_adSiedzKodPocztowy>69000</fiz_adSiedzKodPocztowy>
+        <fiz_adSiedzMiejscowoscPoczty_Symbol>0198380</fiz_adSiedzMiejscowoscPoczty_Symbol>
+        <fiz_adSiedzMiejscowosc_Symbol>0198380</fiz_adSiedzMiejscowosc_Symbol>
+        <fiz_adSiedzUlica_Symbol>1240</fiz_adSiedzUlica_Symbol>
+        <fiz_adSiedzNumerNieruchomosci>99</fiz_adSiedzNumerNieruchomosci>
+        <fiz_adSiedzNumerLokalu />
+        <fiz_adSiedzNietypoweMiejsceLokalizacji />
+        <fiz_numerTelefonu />
+        <fiz_numerWewnetrznyTelefonu />
+        <fiz_numerFaksu>9999999999</fiz_numerFaksu>
+        <fiz_adresEmail />
+        <fiz_adresStronyinternetowej />
+        <fiz_adresEmail2 />
+        <fiz_adSiedzKraj_Nazwa />
+        <fiz_adSiedzWojewodztwo_Nazwa>WIELKOPOLSKIE</fiz_adSiedzWojewodztwo_Nazwa>
+        <fiz_adSiedzPowiat_Nazwa>xxxxxxxxxx</fiz_adSiedzPowiat_Nazwa>
+        <fiz_adSiedzGmina_Nazwa>Yyyyyyyy</fiz_adSiedzGmina_Nazwa>
+        <fiz_adSiedzMiejscowosc_Nazwa>Yyyyyyyy</fiz_adSiedzMiejscowosc_Nazwa>
+        <fiz_adSiedzMiejscowoscPoczty_Nazwa>Yyyyyyyy</fiz_adSiedzMiejscowoscPoczty_Nazwa>
+        <fiz_adSiedzUlica_Nazwa>ul. Adama Mickiewicza</fiz_adSiedzUlica_Nazwa>
+        <fizP_dataWpisuDoRejestruEwidencji />
+        <fizP_numerwRejestrzeEwidencji />
+        <fizP_OrganRejestrowy_Symbol />
+        <fizP_OrganRejestrowy_Nazwa />
+        <fizP_RodzajRejestru_Symbol>099</fizP_RodzajRejestru_Symbol>
+        <fizP_RodzajRejestru_Nazwa>PODMIOTY NIE PODLEGAJĄCE WPISOM DO REJESTRU LUB EWIDENCJI</fizP_RodzajRejestru_Nazwa>
+    </dane>
+</root>


### PR DESCRIPTION
`GusApi::getFullReport()` powinien zwracać wiele pozycji (np. wiele kodów PKD) a nie tylko jedną jak w tej chwili. Dodatkowo zwracany jest `array` zamiast `SimpleXMLElement`.