### PR TITLE
Add session ID check to each API call

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout Code

--- a/tests/GusApiTest.php
+++ b/tests/GusApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GusApi\Tests;
 
+use BadMethodCallException;
 use DateTimeImmutable;
 use DateTimeZone;
 use GusApi\Client\GusApiClient;
@@ -50,7 +51,14 @@ final class GusApiTest extends TestCase
         $this->loginApiWithSessionId('12sessionid21');
         $this->api->login();
 
-        self::assertSame($this->api->getSessionId(), '12sessionid21');
+        self::assertSame('12sessionid21', $this->api->getSessionId());
+    }
+
+    public function testGetSessionIdFailsWhenNotLoggedIn(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Session is not started. Call login() first.');
+        $this->api->getSessionId();
     }
 
     public function testLoginWillThrowExceptionWhenResponseIsEmpty(): void
@@ -81,6 +89,11 @@ final class GusApiTest extends TestCase
     {
         $this->expectGetValueCall('StatusSesji', '1');
         self::assertTrue($this->api->isLogged());
+    }
+
+    public function testIsLoggedReturnsFalseWhenSessionIdIsEmpty(): void
+    {
+        self::assertFalse($this->api->isLogged());
     }
 
     public function testGetDataStatus(): void
@@ -247,6 +260,7 @@ final class GusApiTest extends TestCase
 
     public function testGetBulkReportWillThrowExceptionWhenInvalidReportTypeProvided(): void
     {
+        $this->loginApiWithSessionId('12sessionid21');
         $this->expectException(InvalidReportTypeException::class);
         $this->api->getBulkReport(new DateTimeImmutable(), 'asdf');
     }
@@ -274,6 +288,13 @@ final class GusApiTest extends TestCase
     {
         $this->expectGetValueCall('KomunikatTresc', 'Invalid Test');
         self::assertSame('Invalid Test', $this->api->getMessage());
+    }
+
+    public function testItThrowsBadMethodCallExceptionWhenLoginWasNotCalled(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Session is not started. Call login() first.');
+        $this->api->getMessageCode();
     }
 
     public function testGetSessionStatus(): void


### PR DESCRIPTION
Dodano metodę `ensureSession()`, która rzuca wyjątkiem `BadMethodCallException` jeśli `sessionId` nie został ustawiony.
Metoda `isLogged()` zwraca teraz `false,` jeśli sesja nie została jeszcze rozpoczęta (patrz testy) - tak naprawdę powinno to działać tak samo jak dotychczas ale bez zbędnego zapytania do API (skoro nie ma sesji, to zawsze będzie `false`).


Fixes #115 

Zmiana ta łamie jednak nieco kompatybilność wsteczną - ze względu na nowo rzucany wyjątek. Ma to jednak dość mały wpływ na użytkowanie biblioteki, bo wcześniej rzucany był `TypeError`, jeśli metoda `login()` nie została wywołana.