### PR TITLE
BIR1.2 reports, PKD 2025

### DIFF
--- a/src/GusApi/ReportTypes.php
+++ b/src/GusApi/ReportTypes.php
@@ -6,22 +6,22 @@ namespace GusApi;
 
 final class ReportTypes
 {
-    public const REPORT_PERSON = 'BIR11OsFizycznaDaneOgolne';
-    public const REPORT_PERSON_CEIDG = 'BIR11OsFizycznaDzialalnoscCeidg';
-    public const REPORT_PERSON_AGRO = 'BIR11OsFizycznaDzialalnoscRolnicza';
-    public const REPORT_PERSON_OTHER = 'BIR11OsFizycznaDzialalnoscPozostala';
+    public const REPORT_PERSON = 'BIR12OsFizycznaDaneOgolne';
+    public const REPORT_PERSON_CEIDG = 'BIR12OsFizycznaDzialalnoscCeidg';
+    public const REPORT_PERSON_AGRO = 'BIR12OsFizycznaDzialalnoscRolnicza';
+    public const REPORT_PERSON_OTHER = 'BIR12OsFizycznaDzialalnoscPozostala';
     public const REPORT_PERSON_DELETED_BEFORE_20141108 = 'BIR11OsFizycznaDzialalnoscSkreslonaDo20141108';
-    public const REPORT_PERSON_LOCALS = 'BIR11OsFizycznaListaJednLokalnych';
-    public const REPORT_PERSON_LOCAL = 'BIR11JednLokalnaOsFizycznej';
-    public const REPORT_PERSON_ACTIVITY = 'BIR11OsFizycznaPkd';
-    public const REPORT_PERSON_LOCAL_ACTIVITY = 'BIR11JednLokalnaOsFizycznejPkd';
-    public const REPORT_ORGANIZATION = 'BIR11OsPrawna';
-    public const REPORT_ORGANIZATION_ACTIVITY = 'BIR11OsPrawnaPkd';
-    public const REPORT_ORGANIZATION_LOCALS = 'BIR11OsPrawnaListaJednLokalnych';
-    public const REPORT_ORGANIZATION_LOCAL = 'BIR11JednLokalnaOsPrawnej';
-    public const REPORT_ORGANIZATION_LOCAL_ACTIVITY = 'BIR11JednLokalnaOsPrawnejPkd';
-    public const REPORT_ORGANIZATION_PARTNERS = 'BIR11OsPrawnaSpCywilnaWspolnicy';
-    public const REPORT_UNIT_TYPE = 'BIR11TypPodmiotu';
+    public const REPORT_PERSON_LOCALS = 'BIR12OsFizycznaListaJednLokalnych';
+    public const REPORT_PERSON_LOCAL = 'BIR12JednLokalnaOsFizycznej';
+    public const REPORT_PERSON_ACTIVITY = 'BIR12OsFizycznaPkd';
+    public const REPORT_PERSON_LOCAL_ACTIVITY = 'BIR12JednLokalnaOsFizycznejPkd';
+    public const REPORT_ORGANIZATION = 'BIR12OsPrawna';
+    public const REPORT_ORGANIZATION_ACTIVITY = 'BIR12OsPrawnaPkd';
+    public const REPORT_ORGANIZATION_LOCALS = 'BIR12OsPrawnaListaJednLokalnych';
+    public const REPORT_ORGANIZATION_LOCAL = 'BIR12JednLokalnaOsPrawnej';
+    public const REPORT_ORGANIZATION_LOCAL_ACTIVITY = 'BIR12JednLokalnaOsPrawnejPkd';
+    public const REPORT_ORGANIZATION_PARTNERS = 'BIR12OsPrawnaSpCywilnaWspolnicy';
+    public const REPORT_UNIT_TYPE = 'BIR12TypPodmiotu';
 
     public const REPORTS = [
         self::REPORT_PERSON,

--- a/tests/Client/GusApiClientTest.php
+++ b/tests/Client/GusApiClientTest.php
@@ -338,16 +338,19 @@ final class GusApiClientTest extends TestCase
         $this->assertEquals(
             new GetFullReportResponse([
                 [
+                    'praw_pkdWersja' => '2007',
                     'praw_pkdKod' => '7430Z',
                     'praw_pkdNazwa' => 'DZIAŁALNOŚĆ ZWIĄZANA Z TŁUMACZENIAMI',
                     'praw_pkdPrzewazajace' => '0',
                 ],
                 [
+                    'praw_pkdWersja' => '2007',
                     'praw_pkdKod' => '7420Z',
                     'praw_pkdNazwa' => 'DZIAŁALNOŚĆ FOTOGRAFICZNA',
                     'praw_pkdPrzewazajace' => '0',
                 ],
                 [
+                    'praw_pkdWersja' => '2007',
                     'praw_pkdKod' => '7410Z',
                     'praw_pkdNazwa' => 'DZIAŁALNOŚĆ W ZAKRESIE SPECJALISTYCZNEGO PROJEKTOWANIA',
                     'praw_pkdPrzewazajace' => '1',

--- a/tests/GusApiTest.php
+++ b/tests/GusApiTest.php
@@ -260,7 +260,7 @@ final class GusApiTest extends TestCase
             [['test' => '1234']],
             $this->api->getFullReport(
                 new SearchReport(new SearchResponseCompanyData()),
-                'BIR11OsFizycznaDaneOgolne'
+                'BIR12OsFizycznaDaneOgolne'
             )
         );
     }

--- a/tests/resources/response/fullSearchMultipleResponse.xsd
+++ b/tests/resources/response/fullSearchMultipleResponse.xsd
@@ -1,15 +1,18 @@
 <root>
     <dane>
+        <praw_pkdWersja>2007</praw_pkdWersja>
         <praw_pkdKod>7430Z</praw_pkdKod>
         <praw_pkdNazwa>DZIAŁALNOŚĆ ZWIĄZANA Z TŁUMACZENIAMI</praw_pkdNazwa>
         <praw_pkdPrzewazajace>0</praw_pkdPrzewazajace>
     </dane>
     <dane>
+        <praw_pkdWersja>2007</praw_pkdWersja>
         <praw_pkdKod>7420Z</praw_pkdKod>
         <praw_pkdNazwa>DZIAŁALNOŚĆ FOTOGRAFICZNA</praw_pkdNazwa>
         <praw_pkdPrzewazajace>0</praw_pkdPrzewazajace>
     </dane>
     <dane>
+        <praw_pkdWersja>2007</praw_pkdWersja>
         <praw_pkdKod>7410Z</praw_pkdKod>
         <praw_pkdNazwa>DZIAŁALNOŚĆ W ZAKRESIE SPECJALISTYCZNEGO PROJEKTOWANIA</praw_pkdNazwa>
         <praw_pkdPrzewazajace>1</praw_pkdPrzewazajace>


### PR DESCRIPTION
Dostosowanie GusAPI do zmian usługi sieciowej PKD 2025.
Najistotniejsza zmiana dotyczy dodania elementu <…_pkdWersja> w odpowiedziach xml.

Lista zmian raportów metody PobierzPelnyRaport, wraz ze zmianą odpowiedzi xml:
* BIR11OsFizycznaDaneOgolne => BIR12OsFizycznaDaneOgolne, bez zmian
* BIR11OsFizycznaDzialalnoscCeidg => BIR12OsFizycznaDzialalnoscCeidg, LENGTH(fiz_adSiedzNumerLokalu)=20
* BIR11OsFizycznaDzialalnoscRolnicza => BIR12OsFizycznaDzialalnoscRolnicza, LENGTH(fiz_adSiedzNumerLokalu)=20
* BIR11OsFizycznaDzialalnoscPozostala => BIR12OsFizycznaDzialalnoscPozostala, LENGTH(fiz_adSiedzNumerLokalu)=20
* BIR11OsFizycznaListaJednLokalnych => BIR12OsFizycznaListaJednLokalnych, LENGTH(lokfiz_adSiedzNumerLokalu)=20
* BIR11JednLokalnaOsFizycznej => BIR12JednLokalnaOsFizycznej, LENGTH(lokfiz_adSiedzNumerLokalu)=20
* BIR11OsFizycznaPkd => BIR12OsFizycznaPkd, dodano element fiz_pkdWersja
* BIR11JednLokalnaOsFizycznejPkd => BIR12JednLokalnaOsFizycznejPkd, dodano element lokfiz_pkdWersja
* BIR11OsPrawna => BIR12OsPrawna,LENGTH(praw_adSiedzNumerLokalu)=20
* BIR11OsPrawnaPkd => BIR12OsPrawnaPkd, dodano element praw_pkdWersja
* BIR11OsPrawnaListaJednLokalnych => BIR12OsPrawnaListaJednLokalnych, LENGTH(lokpraw_adSiedzNumerLokalu)=20
* BIR11JednLokalnaOsPrawnej => BIR12JednLokalnaOsPrawnej, LENGTH(lokpraw_adSiedzNumerLokalu)=20
* BIR11JednLokalnaOsPrawnejPkd => BIR12JednLokalnaOsPrawnejPkd, dodano element lokpraw_pkdWersja
* BIR11OsPrawnaSpCywilnaWspolnicy => BIR12OsPrawnaSpCywilnaWspolnicy, bez zmian
* BIR11TypPodmiotu => BIR12TypPodmiotu, bez zmian

Powyższy opis zmian dotyczy Usługi testowej.
W wersji produkcyjnej zmiany zostaną udostępnione od 2025.01.01.

Zmiany oparte na GUS-Regon-UslugaBIRver1.2-dokumentacjaVer1.34,