### PR TITLE
[Chore] Improve tests

### DIFF
--- a/tests/Client/GusApiClientTest.php
+++ b/tests/Client/GusApiClientTest.php
@@ -33,9 +33,9 @@ final class GusApiClientTest extends TestCase
 {
     use GetContentTrait;
 
-    private GusApiClient $gusApiClient;
+    private readonly GusApiClient $gusApiClient;
 
-    private SoapClient|MockObject $soap;
+    private readonly SoapClient&MockObject $soap;
 
     protected function setUp(): void
     {

--- a/tests/Client/SoapActionMapperTest.php
+++ b/tests/Client/SoapActionMapperTest.php
@@ -6,13 +6,12 @@ namespace GusApi\Tests\Client;
 
 use GusApi\Client\SoapActionMapper;
 use GusApi\Exception\InvalidActionNameException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SoapActionMapperTest extends TestCase
 {
-    /**
-     * @dataProvider actionProvider
-     */
+    #[DataProvider('actionProvider')]
     public function testGetActionWithValidName(string $expected, string $functionName): void
     {
         $action = SoapActionMapper::getAction($functionName);
@@ -25,27 +24,16 @@ final class SoapActionMapperTest extends TestCase
         SoapActionMapper::getAction('BadFunctionName');
     }
 
-    public static function actionProvider(): array
+    /**
+     * @return iterable<array{0: string, 1: string}>
+     */
+    public static function actionProvider(): iterable
     {
-        return [
-            [
-                'http://CIS/BIR/2014/07/IUslugaBIR/GetValue', 'GetValue',
-            ],
-            [
-                'http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/Zaloguj', 'Zaloguj',
-            ],
-            [
-                'http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/Wyloguj', 'Wyloguj',
-            ],
-            [
-                'http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/DaneSzukajPodmioty', 'DaneSzukajPodmioty',
-            ],
-            [
-                'http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/DanePobierzPelnyRaport', 'DanePobierzPelnyRaport',
-            ],
-            [
-                'http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/DanePobierzRaportZbiorczy', 'DanePobierzRaportZbiorczy',
-            ],
-        ];
+        yield ['http://CIS/BIR/2014/07/IUslugaBIR/GetValue', 'GetValue'];
+        yield ['http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/Zaloguj', 'Zaloguj'];
+        yield ['http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/Wyloguj', 'Wyloguj'];
+        yield ['http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/DaneSzukajPodmioty', 'DaneSzukajPodmioty'];
+        yield ['http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/DanePobierzPelnyRaport', 'DanePobierzPelnyRaport'];
+        yield ['http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl/DanePobierzRaportZbiorczy', 'DanePobierzRaportZbiorczy'];
     }
 }

--- a/tests/Context/ContextTest.php
+++ b/tests/Context/ContextTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ContextTest extends TestCase
 {
-    private Context $context;
+    private readonly Context $context;
 
     protected function setUp(): void
     {

--- a/tests/Environment/EnvironmentFactoryTest.php
+++ b/tests/Environment/EnvironmentFactoryTest.php
@@ -14,15 +14,36 @@ final class EnvironmentFactoryTest extends TestCase
 {
     public function testCreateWillCreateProdEnvironment(): void
     {
-        self::assertInstanceOf(ProdEnvironment::class, EnvironmentFactory::create('prod'));
+        $environment = EnvironmentFactory::create('prod');
+
+        self::assertInstanceOf(ProdEnvironment::class, $environment);
+        self::assertSame(
+            'https://wyszukiwarkaregon.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl-ver11-prod.wsdl',
+            $environment->getWSDLUrl()
+        );
+        self::assertSame(
+            'https://wyszukiwarkaregon.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc',
+            $environment->getServerLocationUrl()
+        );
     }
 
     public function testCreateWillCreateDevEnvironment(): void
     {
+        $environment = EnvironmentFactory::create('dev');
+
+        self::assertInstanceOf(DevEnvironment::class, $environment);
+        self::assertSame(
+            'https://wyszukiwarkaregontest.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl-ver11-test.wsdl',
+            $environment->getWSDLUrl()
+        );
+        self::assertSame(
+            'https://wyszukiwarkaregontest.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc',
+            $environment->getServerLocationUrl()
+        );
         self::assertInstanceOf(DevEnvironment::class, EnvironmentFactory::create('dev'));
     }
 
-    public function testCreateWillThworExceptionWhenUndefinedEnvironmentProvided(): void
+    public function testCreateWillThrowExceptionWhenUndefinedEnvironmentProvided(): void
     {
         $this->expectException(InvalidEnvironmentNameException::class);
         EnvironmentFactory::create('asdf');


### PR DESCRIPTION
- Add tests for `ProdEnvironment`
- Add coverage for `ReportRegonNumberMapper::getRegonNumberByReportName()`
- Use modern PHP features: Attributes, intersection types and generators
- Add test case for #140 - it should be changed if behaviour is modified in the future