### PR TITLE
[Chore] Fix PHPStan, improve CI

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,34 +5,10 @@ on:
   pull_request:
 
 jobs:
-  composer:
-    name: Composer validation
-    runs-on: ubuntu-24.04
-
-    strategy:
-      matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Execute composer validate
-        run: composer validate --strict
-
   phpcs:
     name: PHPCs
     runs-on: ubuntu-24.04
 
-    strategy:
-      matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -40,14 +16,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.4'
+
+      - name: Execute composer validate
+        run: composer validate --strict
 
       - name: Install Dependencies
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
+        uses: ramsey/composer-install@v3
 
       - name: Execute PHPCs
         run: vendor/bin/phpcs src tests
@@ -58,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
 
     steps:
       - name: Checkout code
@@ -70,11 +45,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Dependencies
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
+        uses: ramsey/composer-install@v3
 
       - name: Execute PHPStan
         run: vendor/bin/phpstan --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout Code
@@ -21,37 +21,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-
-      - name: Install Dependencies
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
-
-      - name: Execute PHPUnit
-        run: vendor/bin/phpunit
-
-  coverage:
-    name: Test Coverage
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v5
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
           coverage: pcov
 
       - name: Install Dependencies
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
+        uses: ramsey/composer-install@v3
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit --coverage-clover=./coverage.xml

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method GusApi\\Client\\GusApiClient\:\:getBulkReport\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Client/GusApiClient.php
-
-		-
 			message: '#^Method GusApi\\Client\\GusApiClient\:\:getValue\(\) should return GusApi\\Type\\Response\\GetValueResponse but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -43,157 +37,13 @@ parameters:
 			path: src/GusApi/Client/GusApiClient.php
 
 		-
-			message: '#^Method GusApi\\Context\\Context\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Method SoapClient\:\:__doRequest\(\) invoked with 6 parameters, 4\-5 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/GusApi/Client/SoapClient.php
+
+		-
+			message: '#^Method GusApi\\Context\\Context\:\:getOptions\(\) should return array\<string, mixed\> but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: src/GusApi/Context/Context.php
-
-		-
-			message: '#^Method GusApi\\Context\\Context\:\:getParameters\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/Context.php
-
-		-
-			message: '#^Method GusApi\\Context\\Context\:\:setOptions\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/Context.php
-
-		-
-			message: '#^Method GusApi\\Context\\Context\:\:setParameters\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/Context.php
-
-		-
-			message: '#^Method GusApi\\Context\\ContextInterface\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/ContextInterface.php
-
-		-
-			message: '#^Method GusApi\\Context\\ContextInterface\:\:getParameters\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/ContextInterface.php
-
-		-
-			message: '#^Method GusApi\\Context\\ContextInterface\:\:setOptions\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/ContextInterface.php
-
-		-
-			message: '#^Method GusApi\\Context\\ContextInterface\:\:setParameters\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Context/ContextInterface.php
-
-		-
-			message: '#^Method GusApi\\GusApi\:\:checkIdentifiersCount\(\) has parameter \$identifiers with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/GusApi.php
-
-		-
-			message: '#^Method GusApi\\GusApi\:\:getBulkReport\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/GusApi.php
-
-		-
-			message: '#^Method GusApi\\SearchReport\:\:jsonSerialize\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/SearchReport.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\GetBulkReport\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/GetBulkReport.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\GetFullReport\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/GetFullReport.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\GetValue\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/GetValue.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\Login\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/Login.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\Logout\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/Logout.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\RequestInterface\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/RequestInterface.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\SearchData\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/SearchData.php
-
-		-
-			message: '#^Method GusApi\\Type\\Request\\SearchParameters\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Type/Request/SearchParameters.php
-
-		-
-			message: '#^Method GusApi\\Util\\BulkReportResponseDecoder\:\:decode\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/GusApi/Util/BulkReportResponseDecoder.php
-
-		-
-			message: '#^Cannot call method method\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Client/GusApiClientTest.php
-
-		-
-			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Client/GusApiClientTest.php
-
-		-
-			message: '#^Cannot call method with\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Client/GusApiClientTest.php
-
-		-
-			message: '#^Method GusApi\\Tests\\Client\\GusApiClientTest\:\:expectSoapCall\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/Client/GusApiClientTest.php
-
-		-
-			message: '#^Method GusApi\\Tests\\Client\\GusApiClientTest\:\:getHeaders\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/Client/GusApiClientTest.php
-
-		-
-			message: '#^Method GusApi\\Tests\\Client\\SoapActionMapperTest\:\:actionProvider\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/Client/SoapActionMapperTest.php

--- a/src/GusApi/Client/GusApiClient.php
+++ b/src/GusApi/Client/GusApiClient.php
@@ -70,6 +70,9 @@ class GusApiClient
         return FullReportResponseDecoder::decode($rawResponse);
     }
 
+    /**
+     * @return list<string>
+     */
     public function getBulkReport(GetBulkReport $getBulkReport, string $sessionId): array
     {
         $rawResponse = $this->call('DanePobierzRaportZbiorczy', $getBulkReport, $sessionId);

--- a/src/GusApi/Client/SoapClient.php
+++ b/src/GusApi/Client/SoapClient.php
@@ -6,9 +6,17 @@ namespace GusApi\Client;
 
 class SoapClient extends \SoapClient
 {
-    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): string
-    {
-        $response = parent::__doRequest($request, $location, $action, $version, $oneWay);
+    public function __doRequest(
+        string $request,
+        string $location,
+        string $action,
+        int $version,
+        bool $oneWay = false,
+        ?string $uriParserClass = null
+    ): string {
+        $response = (\PHP_VERSION_ID >= 80500)
+            ? parent::__doRequest($request, $location, $action, $version, $oneWay, $uriParserClass)
+            : parent::__doRequest($request, $location, $action, $version, $oneWay);
 
         return MultipartResponseDecoder::decode((string) $response);
     }

--- a/src/GusApi/Context/Context.php
+++ b/src/GusApi/Context/Context.php
@@ -30,6 +30,9 @@ final class Context implements ContextInterface
         return stream_context_set_params($this->context, $parameters);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
         return stream_context_get_options($this->context);

--- a/src/GusApi/Context/ContextInterface.php
+++ b/src/GusApi/Context/ContextInterface.php
@@ -6,12 +6,24 @@ namespace GusApi\Context;
 
 interface ContextInterface
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function setOptions(array $options): bool;
 
+    /**
+     * @param array<string, mixed> $parameters
+     */
     public function setParameters(array $parameters): bool;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getParameters(): array;
 
     /**

--- a/src/GusApi/GusApi.php
+++ b/src/GusApi/GusApi.php
@@ -269,6 +269,8 @@ class GusApi
     }
 
     /**
+     * @return string[]
+     *
      * @throws InvalidReportTypeException
      */
     public function getBulkReport(DateTimeImmutable $date, string $reportName): array
@@ -320,6 +322,9 @@ class GusApi
         return (int) $response->getGetValueResult();
     }
 
+    /**
+     * @param string[] $identifiers
+     */
     private function checkIdentifiersCount(array $identifiers): void
     {
         if (\count($identifiers) > self::MAX_IDENTIFIERS) {

--- a/src/GusApi/SearchReport.php
+++ b/src/GusApi/SearchReport.php
@@ -167,6 +167,9 @@ class SearchReport implements JsonSerializable
         return trim(strtolower($type));
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return get_object_vars($this);

--- a/src/GusApi/Type/Request/RequestInterface.php
+++ b/src/GusApi/Type/Request/RequestInterface.php
@@ -7,7 +7,7 @@ namespace GusApi\Type\Request;
 interface RequestInterface
 {
     /**
-     * @return array<string, string|int|array|null>
+     * @return array<string, mixed>
      */
     public function toArray(): array;
 }

--- a/src/GusApi/Type/Request/SearchData.php
+++ b/src/GusApi/Type/Request/SearchData.php
@@ -12,6 +12,9 @@ final class SearchData implements RequestInterface
     {
     }
 
+    /**
+     * @return array{'pParametryWyszukiwania': array<string, string|null>}
+     */
     public function toArray(): array
     {
         return [

--- a/src/GusApi/Type/Request/SearchParameters.php
+++ b/src/GusApi/Type/Request/SearchParameters.php
@@ -10,6 +10,17 @@ class SearchParameters implements RequestInterface
     {
     }
 
+    /**
+     * @return array{
+     *     'Krs': string|null,
+     *     'Krsy': string|null,
+     *     'Nip': string|null,
+     *     'Nipy': string|null,
+     *     'Regon': string|null,
+     *     'Regony9zn': string|null,
+     *     'Regony14zn': string|null
+     * }
+     */
     public function toArray(): array
     {
         return [

--- a/src/GusApi/Util/BulkReportResponseDecoder.php
+++ b/src/GusApi/Util/BulkReportResponseDecoder.php
@@ -12,6 +12,8 @@ class BulkReportResponseDecoder
 {
     /**
      * @throws InvalidServerResponseException
+     *
+     * @return list<string>
      */
     public static function decode(GetBulkReportResponseRaw $bulkReportResponseRaw): array
     {

--- a/tests/Client/GusApiClientTest.php
+++ b/tests/Client/GusApiClientTest.php
@@ -360,6 +360,9 @@ final class GusApiClientTest extends TestCase
         );
     }
 
+    /**
+     * @return \SoapHeader[]
+     */
     private function getHeaders(string $action, string $to): array
     {
         return [
@@ -368,6 +371,9 @@ final class GusApiClientTest extends TestCase
         ];
     }
 
+    /**
+     * @param list<mixed> $arguments
+     */
     private function expectSoapCall(string $action, array $arguments, object $result, bool $public = true): void
     {
         $baseUrl = $public ? 'http://CIS/BIR/PUBL/2014/07/IUslugaBIRzewnPubl' : 'http://CIS/BIR/2014/07/IUslugaBIR';


### PR DESCRIPTION
- Poprawione kilka błędów z PHPStan
- Połączone `composer validate` i `phpcs`, uruchamiane tylko na jednej wersji PHP
- Dodanie kompatybilności z PHP 8.5 (`SoapClient::__doRequest()`)
- Połączenie jobów `coverage` i `test` - w ten sposób CodeCov połączy raporty z różnych wersji PHP, szczególnie przydatne tutaj: https://github.com/johnzuk/GusApi/blob/02b861d3f5006898c3c13f8384a524a60e21c77f/src/GusApi/Context/Context.php#L21-L23

PS. Wygląda na to, że codecov od jakiegoś czasu nie procesuje raportów - chyba trzeba zainstalować ich aplikację.